### PR TITLE
Setup Basic Rack Server

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,5 @@ gem "rack", "~> 2.2"
 gem "rack-test", "~> 1.1", group: :test
 
 gem "webrick", "~> 1.7"
+
+gem 'rubocop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,48 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.3)
     coderay (1.1.3)
+    json (2.13.2)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
     method_source (1.0.0)
+    parallel (1.27.0)
+    parser (3.3.9.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.4.0)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    racc (1.8.1)
     rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
+    rainbow (3.1.1)
+    regexp_parser (2.10.0)
+    rubocop (1.79.1)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.46.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.46.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.4)
+    ruby-progressbar (1.13.0)
+    unicode-display_width (3.1.4)
+      unicode-emoji (~> 4.0, >= 4.0.4)
+    unicode-emoji (4.0.4)
     webrick (1.7.0)
 
 PLATFORMS
+  arm64-darwin-24
   universal-darwin-20
   universal-darwin-21
 
@@ -19,6 +50,7 @@ DEPENDENCIES
   pry
   rack (~> 2.2)
   rack-test (~> 1.1)
+  rubocop
   webrick (~> 1.7)
 
 BUNDLED WITH

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,18 @@
+require 'rack'
+require 'pry'
+
+class App
+  def call(env)
+    path = env['PATH_INFO']
+
+    if path == '/'
+      [200, { 'Content-Type' => 'text/html' }, ['<h2>Hello <em>World</em>!</h2>']]
+    elsif path == '/potato'
+      [200, { 'Content-Type' => 'text/html' }, ["<p>Boil 'em, mash 'em, stick 'em in a stew</p>"]]
+    else
+      [404, { 'Content-Type' => 'text/html' }, ['Page not found']]
+    end
+  end
+end
+
+run App.new

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,10 +2,10 @@ require 'rack'
 require 'rack/test'
 
 def app
-  Rack::Builder.parse_file('config.ru').first
+  Rack::Builder.parse_file('config.ru')
 end
 
 RSpec.configure do |config|
   config.include Rack::Test::Methods
-  config.order = 'default'
+  config.order = 'defined'
 end


### PR DESCRIPTION
This pull request introduces a basic Rack application, adds a new dependency for code linting, and updates the test configuration for consistency. The most important changes include creating a simple Rack application in `config.ru`, adding the `rubocop` gem, and modifying the RSpec configuration.

### Rack application implementation:
* [`config.ru`](diffhunk://#diff-5fe74a7aca8668f86d1251d17e23b3ac9c55504d8d78698a8168a9cae87b350cR1-R18): Added a simple Rack application (`App`) that handles three routes: `/` (returns "Hello World"), `/potato` (returns a quote), and a fallback for 404 errors.

### Dependency addition:
* [`Gemfile`](diffhunk://#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55fR10-R11): Added the `rubocop` gem for code linting.

### Test configuration updates:
* [`spec/spec_helper.rb`](diffhunk://#diff-89eebfcbc0f14b6d989517837ca1e94fce4e2ce9a03233641cd936f2b8d2ed94L5-R10): Updated the `app` method to return the full Rack application stack instead of just the first middleware. Changed the RSpec order configuration from `default` to `defined` to ensure tests run in the order they are defined.