### PR TITLE
Fix Deprecated Spec Ordering Strategy and Remove .first

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,10 +2,10 @@ require 'rack'
 require 'rack/test'
 
 def app
-  Rack::Builder.parse_file('config.ru').first
+  Rack::Builder.parse_file('config.ru')
 end
 
 RSpec.configure do |config|
   config.include Rack::Test::Methods
-  config.order = 'default'
+  config.order = 'defined'
 end


### PR DESCRIPTION
This pull request includes minor updates to the `spec/spec_helper.rb` file to align with best practices and improve test configuration.

Test configuration updates:

* Updated the `app` method to return the full result of `Rack::Builder.parse_file('config.ru')` instead of just the first element, which allows the specs to run.
* Changed the RSpec configuration to use `config.order = 'defined'` instead of `config.order = 'default'`, which is deprecated. 